### PR TITLE
Mentions now allowed in ascii command

### DIFF
--- a/Core/Giphy.py
+++ b/Core/Giphy.py
@@ -26,11 +26,9 @@ async def giphy(message, client):
 async def ascii(message, client):
     try:
         f = Figlet()
-        toreturn = f.renderText((message.content[7:]))
+        toreturn = f.renderText((message.clean_content[7:]))
         if toreturn.strip() is "":  # So that it doesn't just return "``````"
             await message.channel.send(":x: Error getting ascii. This message is either empty or contains only unicode. :x:")
-        elif message.mentions:
-            await message.channel.send(":x: Ascii command cannot handle mentions. :x:")
         else:
             toreturn = "```" + toreturn + "```"
             await message.channel.send(toreturn)

--- a/Core/Giphy.py
+++ b/Core/Giphy.py
@@ -29,7 +29,7 @@ async def ascii(message, client):
         toreturn = f.renderText((message.content[7:]))
         if toreturn.strip() is "":  # So that it doesn't just return "``````"
             await message.channel.send(":x: Error getting ascii. This message is either empty or contains only unicode. :x:")
-        elif "@" in message.content:
+        elif message.mentions:
             await message.channel.send(":x: Ascii command cannot handle mentions. :x:")
         else:
             toreturn = "```" + toreturn + "```"


### PR DESCRIPTION
error only thrown when an actual mention is made

## Problem
- "@" triggers the error for mentions

## Solution
- message.clean_content returns content as seen by end users. Allowing for normal use of mentions in ascii command

## Old Commands affected
- ~ascii

## Reviewers
- [ ] @JessWalters
- [ ]
- [ ]
- # TODO: Add any other users you want to help review this pr.
