### PR TITLE
Battle royale command

### DIFF
--- a/Core/Parser.py
+++ b/Core/Parser.py
@@ -283,6 +283,10 @@ async def parseCommand(message, client):
             await games(message, client)
             logCommand(message, client, '~games')
 
+        elif message.content.startswith('~battleroyaleverbose'):
+            await battle_royale(message, client, True)
+            logCommand(message, client, "~battleroyaleverbose")
+            
         elif message.content.startswith('~battleroyale'):
             await battle_royale(message, client, False)
             logCommand(message, client, '~battleroyale')

--- a/Core/Parser.py
+++ b/Core/Parser.py
@@ -284,7 +284,7 @@ async def parseCommand(message, client):
             logCommand(message, client, '~games')
 
         elif message.content.startswith('~battleroyale'):
-            await battle_royale(message, client)
+            await battle_royale(message, client, False)
             logCommand(message, client, '~battleroyale')
 
         elif message.content.startswith('~battle'):

--- a/Core/Parser.py
+++ b/Core/Parser.py
@@ -286,7 +286,7 @@ async def parseCommand(message, client):
         elif message.content.startswith('~battleroyaleverbose'):
             await battle_royale(message, client, True)
             logCommand(message, client, "~battleroyaleverbose")
-            
+
         elif message.content.startswith('~battleroyale'):
             await battle_royale(message, client, False)
             logCommand(message, client, '~battleroyale')

--- a/Core/playing.py
+++ b/Core/playing.py
@@ -133,23 +133,12 @@ async def battle(message, client):
         winner_name = defender_name
     await message.channel.send(winner_name + " defeated " + loser_name + "!")
 
+
 async def battle_royale(message, client):
+    # get candidates from mention/role/guild list
     candidates = await get_player_list(message)
-    # Get fighters' nicks and names into a list
-    fighters = {}
-    for index, candidate in enumerate(candidates):
-        # filter out bots
-        if candidate.bot:
-            continue
-        nameo = candidate.nick
-        if nameo is None:
-            nameo = candidate.name
-        # Each player has a dictionary with current hp, mentionable name, and player key to get revenge on.
-        fighters[str(index)] = {}
-        fighters[str(index)]["name"] = nameo
-        fighters[str(index)]["hp"] = 100
-        fighters[str(index)]["mention"] = candidate.mention
-        fighters[str(index)]["revenge"] = None
+    # get fighters from candidates
+    fighters = await populate_roster(candidates)
 
     # Weed out any fringe cases
     if len(fighters) < 3:
@@ -296,3 +285,21 @@ async def get_player_list(message):
     else:
         candidates = message.guild.members
     return candidates
+
+
+async def populate_roster(candidates):
+    # add eligible candidates to the fighters list
+    fighters = {}
+    for index, candidate in enumerate(candidates):
+        # filter out bots
+        if candidate.bot:
+            continue
+        name = candidate.nick
+        if name is None:
+            name = candidate.name
+        # Each player has a dictionary with hp, name, and revenge key
+        fighters[str(index)] = {}
+        fighters[str(index)]["name"] = name
+        fighters[str(index)]["hp"] = 100
+        fighters[str(index)]["revenge"] = None
+    return fighters

--- a/Core/playing.py
+++ b/Core/playing.py
@@ -134,11 +134,27 @@ async def battle(message, client):
     await message.channel.send(winner_name + " defeated " + loser_name + "!")
 
 async def battle_royale(message, client):
-    candidates = None
+    candidates = list()
     # Get contestant list
     # if there are mentions, use them. Otherwise, use all guild members
+    roles = message.guild.roles
+    content = message.content
+    role = None
+    if len(message.content.split(" ")) > 1:
+        role_a = content.split(" ")[1]
+        for role_b in roles:
+            if role_b.mention == role_a:
+                role = role_b
+
+    # add users by mention if here are mentions
     if len(message.mentions) > 0:
         candidates = message.mentions
+    # add users by role if a role was mentioned
+    elif role is not None:
+        for applicant in message.guild.members:
+            if role in applicant.roles:
+                candidates.append(applicant)
+    # add all users
     else:
         candidates = message.guild.members
 

--- a/Core/playing.py
+++ b/Core/playing.py
@@ -134,30 +134,7 @@ async def battle(message, client):
     await message.channel.send(winner_name + " defeated " + loser_name + "!")
 
 async def battle_royale(message, client):
-    candidates = list()
-    # Get contestant list
-    # if there are mentions, use them. Otherwise, use all guild members
-    roles = message.guild.roles
-    content = message.content
-    role = None
-    if len(message.content.split(" ")) > 1:
-        role_a = content.split(" ")[1]
-        for role_b in roles:
-            if role_b.mention == role_a:
-                role = role_b
-
-    # add users by mention if here are mentions
-    if len(message.mentions) > 0:
-        candidates = message.mentions
-    # add users by role if a role was mentioned
-    elif role is not None:
-        for applicant in message.guild.members:
-            if role in applicant.roles:
-                candidates.append(applicant)
-    # add all users
-    else:
-        candidates = message.guild.members
-
+    candidates = await get_player_list(message)
     # Get fighters' nicks and names into a list
     fighters = {}
     for index, candidate in enumerate(candidates):
@@ -291,3 +268,31 @@ async def battle_royale(message, client):
     else:
         victor = fighters[random.choice(list(fighters))]["name"]
         await message.channel.send(win_message.format(victor, message.guild.name))
+
+
+async def role_mentioned(message):
+    if len(message.content.split(" ")) > 1:
+        find_role = message.content.split(" ")[1]
+        for role in message.guild.roles:
+            if role.mention == find_role:
+                return role
+    return None
+
+
+async def get_player_list(message):
+    candidates = list()
+    # Get contestant list
+    # if there are mentions, use them. Otherwise, use all guild members
+    role = await role_mentioned(message)
+    # add users by mention if here are mentions
+    if len(message.mentions) > 0:
+        candidates = message.mentions
+    # add users by role if a role was mentioned
+    elif role is not None:
+        for applicant in message.guild.members:
+            if role in applicant.roles:
+                candidates.append(applicant)
+    # add all users
+    else:
+        candidates = message.guild.members
+    return candidates

--- a/Core/playing.py
+++ b/Core/playing.py
@@ -134,12 +134,13 @@ async def battle(message, client):
     await message.channel.send(winner_name + " defeated " + loser_name + "!")
 
 async def battle_royale(message, client):
+    candidates = None
     # Get contestant list
-    candidates = message.guild.members
-    # Weed out any fringe cases
-    if len(candidates) < 3:
-        await message.channel.send(":x:It's not a battle royal if you don't have at least 3 fighters:x:")
-        return
+    # if there are mentions, use them. Otherwise, use all guild members
+    if len(message.mentions) > 0:
+        candidates = message.mentions
+    else:
+        candidates = message.guild.members
 
     # Get fighters' nicks and names into a list
     fighters = {}
@@ -157,6 +158,10 @@ async def battle_royale(message, client):
         fighters[str(index)]["mention"] = candidate.mention
         fighters[str(index)]["revenge"] = None
 
+    # Weed out any fringe cases
+    if len(fighters) < 3:
+        await message.channel.send(":x:It's not a battle royal if you don't have at least 3 fighters:x:")
+        return
     round_count = 0
     # As long as there is more than 1 fighter, do another round.
     while len(fighters) > 1:
@@ -249,7 +254,7 @@ async def battle_royale(message, client):
         await message.channel.send(output)
 
         # print hp report
-        output = "```\nRemaining Contestants:\n"
+        output = "```\nRemaining Contestants: {}\n".format(len(fighters))
         for contestant in fighters:
             line = "{:{x}}: {:3}\n".format(fighters[contestant]["name"], fighters[contestant]["hp"], x=name_len)
             if len(output) + len(line) < 1900:


### PR DESCRIPTION
## Problem
- Too many messages all at once
- Not enough options

## Issue
- Rate of messages was flooding chat and pushing the limits of what the api could handle

## Solution
- Make two versions of the command, ~battleroyale and ~battleroyaleverbose

## New Commands added
- ~battleroyaleverbose: same function as the old ~battleroyale command

## Old Commands affected
- ~battleroyal: now only prints current players and deaths this round; much more manageable

## Reviewers
- [ ] @JessWalters
