### PR TITLE
Battle royale command

### DIFF
--- a/Core/playing.py
+++ b/Core/playing.py
@@ -159,6 +159,62 @@ async def battle_royale(message, client, verbose):
         await message.channel.send("```\nBehold your champion, {} of {}!\n```".format(victor, message.guild.name))
 
 
+async def equip_combatant(fighters, index):
+    fighters[index]["weapon"] = {}
+    fighters[index]["armor"] = {}
+
+    # Roll for weapon
+    luck = randint(0, 10000)
+    if 0 <= luck <= 4900:
+        fighters[index]["weapon"]["name"] = "fist"
+        fighters[index]["weapon"]["damage"] = 0
+    elif 5000 < luck <= 7500:
+        fighters[index]["weapon"]["name"] = "knife"
+        fighters[index]["weapon"]["damage"] = 1
+    elif 7500 < luck <= 8500:
+        fighters[index]["weapon"]["name"] = "machete"
+        fighters[index]["weapon"]["damage"] = 2
+    elif 8500 < luck <= 9300:
+        fighters[index]["weapon"]["name"] = "pistol"
+        fighters[index]["weapon"]["damage"] = 4
+    elif 9300 < luck <= 9600:
+        fighters[index]["weapon"]["name"] = "shotgun"
+        fighters[index]["weapon"]["damage"] = 6
+    elif 9600 < luck <= 9700:
+        fighters[index]["weapon"]["name"] = "wok"
+        fighters[index]["weapon"]["damage"] = 9
+    elif 9700 < luck <= 9900:
+        fighters[index]["weapon"]["name"] = "assault rifle"
+        fighters[index]["weapon"]["damage"] = 10
+    elif 9900 < luck <= 10000:
+        fighters[index]["weapon"]["name"] = "sniper rifle"
+        fighters[index]["weapon"]["damage"] = 15
+    # Reroll for armor
+    luck = randint(0, 10000)
+    if 0 <= luck <= 5000:
+        fighters[index]["armor"]["name"] = "t-shirt"
+        fighters[index]["armor"]["resist"] = 0
+    elif 5000 < luck <= 7500:
+        fighters[index]["armor"]["name"] = "sweatshirt"
+        fighters[index]["armor"]["resist"] = 1
+    elif 7500 < luck <= 8500:
+        fighters[index]["armor"]["name"] = "bike helmet"
+        fighters[index]["armor"]["resist"] = 2
+    elif 8500 < luck <= 9300:
+        fighters[index]["armor"]["name"] = "police vest"
+        fighters[index]["armor"]["resist"] = 3
+    elif 9300 < luck <= 9700:
+        fighters[index]["armor"]["name"] = "kevlar"
+        fighters[index]["armor"]["resist"] = 4
+    elif 9700 < luck <= 9900:
+        fighters[index]["armor"]["name"] = "SWAT gear"
+        fighters[index]["armor"]["resist"] = 6
+    elif 9900 < luck <= 1000:
+        fighters[index]["armor"]["name"] = "wok"
+        fighters[index]["armor"]["resist"] = 8
+    return fighters
+
+
 async def role_mentioned(message):
     # If there is more than 1 element (the command) in the message, see if it's a role.
     if len(message.content.split(" ")) > 1:
@@ -233,8 +289,7 @@ async def enact_attack(fighters, attacker, defender, verbose):
         # Get the max name length
         name_len = 0
         for fighter in fighters:
-            if len(fighters[fighter]["name"]) > name_len:
-                name_len = len(fighters[fighter]["name"])
+            name_len = max(len(fighters[fighter]["name"]), name_len)
         # Print the default format attack
         battle_report += "{:{x}} hits {:{y}} for {:>2}".format(fighters[attacker]["name"], ("themself" if attacker is target else fighters[target]["name"]), str(damage), x=name_len, y=name_len)
         # When attacker is the last person, print special messages
@@ -329,4 +384,5 @@ async def enact_battle(message, fighters, verbose):
         output += "```"
         await message.channel.send(output)
         time.sleep(1)
+        # TODO - print hp in verbose
 

--- a/Core/playing.py
+++ b/Core/playing.py
@@ -147,6 +147,16 @@ async def battle_royale(message, client, verbose):
         return
 
     # TODO - alphabatize fighters by name
+    #temp_fighters = fighters
+    #fighters = {}
+    #keys = list()
+    #for fighter in fighters:
+    #    keys += fighters[fighter]["name"]
+    #keys.sort()
+    #while len(temp_fighters) > 0:
+    #    key = keys.pop()
+    #    print(key)
+    #    fighters[key] = temp_fighters.pop(key)
 
     # Enact the battle of our lifetimes
     await enact_battle(message, fighters, verbose)
@@ -259,6 +269,7 @@ async def populate_roster(candidates):
         fighters[str(index)]["name"] = name
         fighters[str(index)]["hp"] = 100
         fighters[str(index)]["revenge"] = None
+        equip_combatant(fighters, str(index))
     return fighters
 
 
@@ -357,7 +368,6 @@ async def enact_battle(message, fighters, verbose):
         for fighter in fighters:
             name_len = max(len(fighters[fighter]["name"]), name_len)
         battle_report = await enact_round(fighters, name_len, verbose)
-        # TODO - comment below here
         # Split the battle report into an array of each line
         line_by_line = battle_report.split("\n")
         round_count += 1

--- a/Core/playing.py
+++ b/Core/playing.py
@@ -429,12 +429,12 @@ async def enact_battle(message, fighters, verbose):
                 output += "```"
                 await message.channel.send(output)
                 output = "```\n" + line + "\n"
-                time.sleep(1)
+                time.sleep(1.25)
         output += "```"
         await message.channel.send(output)
+        time.sleep(1.25)
         # In verbose mode, print all combatant's hp
         if verbose:
-            time.sleep(1)
             output = "```\nRemaining Combatants: {}\n".format(len(fighters))
             for fighter in fighters:
                 line = "{:{x}}: {:<2}\n".format(fighters[fighter]["name"], fighters[fighter]["hp"], x=name_len)
@@ -443,7 +443,9 @@ async def enact_battle(message, fighters, verbose):
                 else:
                     output += "```"
                     await message.channel.send(output)
+                    time.sleep(1.25)
                     output = "```\n{}".format(line)
             output += "```"
             await message.channel.send(output)
+            time.sleep(1.25)
 


### PR DESCRIPTION
## Problem
- Battleroyale commands change the alignment during the round when the player with the longest name dies. Verbose version was not printing player's remaining hp at the end of each round

## Issue
- N/A

## Solution
- Added printout for player hp every round, and froze alignment changes during the round

## New Commands added
- N/A

## Old Commands affected
- ~battleroyaleverbose and ~battleroyale now use weapons and armor for calculating damage
- ~battleroyaleverbose now prints remaining hp and more flavor text for weapon attacks

## Reviewers
- [ ] @JessWalters
- [ ] @Tyranomaster
